### PR TITLE
[TS-807] Added increased accuracy for temperature readings.

### DIFF
--- a/include/params/devp_scd4x_service_mode.h
+++ b/include/params/devp_scd4x_service_mode.h
@@ -12,6 +12,13 @@
 /**
  * Initialize SCD4X service mode parameters.
  */
-void devp_scd4x_service_mode_init();
+void devp_scd4x_service_mode_init ();
+
+/**
+* Initialize SCD4X default tempoffset
+*/
+void dp_scd4x_tempoffs_default_init ();
+
+uint32_t devp_scd4x_tempoffs_default_get ();
 
 #endif//DEVP_SCD4X_SERVICE_MODE_H_

--- a/include/params/devp_scd4x_service_mode.h
+++ b/include/params/devp_scd4x_service_mode.h
@@ -19,6 +19,6 @@ void devp_scd4x_service_mode_init ();
 */
 void dp_scd4x_tempoffs_default_init ();
 
-uint32_t devp_scd4x_tempoffs_default_get ();
+int32_t devp_scd4x_tempoffs_default_get ();
 
 #endif//DEVP_SCD4X_SERVICE_MODE_H_

--- a/src/params/devp_scd4x_service_mode.c
+++ b/src/params/devp_scd4x_service_mode.c
@@ -344,15 +344,15 @@ static int dp_scd4x_hum_get(devp_t * param, void * value)
 }
 // -----------------------------------------------------------------------------
 
-static uint32_t m_scd4x_tempoffs_default;
+static int32_t m_scd4x_tempoffs_default;
 
 static int dp_scd4x_tempoffs_default_get (devp_t * param, void * value);
 static int dp_scd4x_tempoffs_default_set (devp_t * param, bool init, const void * value, uint8_t size);
 
 static devp_t m_dp_scd4x_tempoffs_default = {
 	.name = "scd4x_tempoffs_default",
-	.type = DP_TYPE_UINT32,
-	.size = sizeof(uint32_t),
+	.type = DP_TYPE_INT32,
+	.size = sizeof(int32_t),
 	.persist = true,
 	.getf = dp_scd4x_tempoffs_default_get,
 	.setf = dp_scd4x_tempoffs_default_set
@@ -360,14 +360,14 @@ static devp_t m_dp_scd4x_tempoffs_default = {
 
 static int dp_scd4x_tempoffs_default_get (devp_t * param, void * value)
 {
-	*((uint32_t*)value) = m_scd4x_tempoffs_default;
-	return sizeof(uint32_t);
+	*((int32_t*)value) = m_scd4x_tempoffs_default;
+	return sizeof(int32_t);
 }
 
 static int dp_scd4x_tempoffs_default_set (devp_t * param, bool init, const void * value, uint8_t size)
 {
-	m_scd4x_tempoffs_default = *((uint32_t*)value);
-	return sizeof(uint32_t);
+	m_scd4x_tempoffs_default = *((int32_t*)value);
+	return sizeof(int32_t);
 }
 
 void dp_scd4x_tempoffs_default_init ()
@@ -376,7 +376,7 @@ void dp_scd4x_tempoffs_default_init ()
     devp_register(&m_dp_scd4x_tempoffs_default);
 }
 
-uint32_t devp_scd4x_tempoffs_default_get ()
+int32_t devp_scd4x_tempoffs_default_get ()
 {
     return m_scd4x_tempoffs_default;
 }

--- a/src/params/devp_scd4x_service_mode.c
+++ b/src/params/devp_scd4x_service_mode.c
@@ -109,12 +109,12 @@ static bool scd_get(int32_t * pco2, uint16_t * ptmp, int32_t * phum)
         if (NO_ERROR == error)
         {
             *pco2 = temp_samples_co2;
-            *ptmp = temp_samples_tmp / 1000;
-            *phum = temp_samples_hum / 1000;
+            *ptmp = temp_samples_tmp / 100;
+            *phum = temp_samples_hum / 100;
             debug1("CO2: %d ppm, T: %d/10 *C, HUM: %d/10 %%RH",
                 (int)(temp_samples_co2),
-                (int)((temp_samples_tmp/1000) * 10),
-                (int)((temp_samples_hum/1000) * 10));
+                (int)(temp_samples_tmp/100),
+                (int)(temp_samples_hum/100));
             return error;
         }
         else
@@ -305,7 +305,7 @@ static int dp_scd4x_temp_get(devp_t * param, void * value)
             return DEVP_EFAIL;
         }
 #endif //TBCO2
-        *((int32_t*)value) = temp * 10;
+        *((int32_t*)value) = temp;
         return sizeof(int32_t);
     }
     return DEVP_EOFF;
@@ -343,6 +343,44 @@ static int dp_scd4x_hum_get(devp_t * param, void * value)
     return DEVP_EOFF;
 }
 // -----------------------------------------------------------------------------
+
+static uint32_t m_scd4x_tempoffs_default;
+
+static int dp_scd4x_tempoffs_default_get (devp_t * param, void * value);
+static int dp_scd4x_tempoffs_default_set (devp_t * param, bool init, const void * value, uint8_t size);
+
+static devp_t m_dp_scd4x_tempoffs_default = {
+	.name = "scd4x_tempoffs_default",
+	.type = DP_TYPE_UINT32,
+	.size = sizeof(uint32_t),
+	.persist = true,
+	.getf = dp_scd4x_tempoffs_default_get,
+	.setf = dp_scd4x_tempoffs_default_set
+};
+
+static int dp_scd4x_tempoffs_default_get (devp_t * param, void * value)
+{
+	*((uint32_t*)value) = m_scd4x_tempoffs_default;
+	return sizeof(uint32_t);
+}
+
+static int dp_scd4x_tempoffs_default_set (devp_t * param, bool init, const void * value, uint8_t size)
+{
+	m_scd4x_tempoffs_default = *((uint32_t*)value);
+	return sizeof(uint32_t);
+}
+
+void dp_scd4x_tempoffs_default_init ()
+{
+    m_scd4x_tempoffs_default = 0;
+    devp_register(&m_dp_scd4x_tempoffs_default);
+}
+
+uint32_t devp_scd4x_tempoffs_default_get ()
+{
+    return m_scd4x_tempoffs_default;
+}
+
 
 // -----------------------------------------------------------------------------
 static int dp_scd4x_tempoffs_get(devp_t * param, void * value);


### PR DESCRIPTION
Added default temperature offset which uses persistent memory. Currently default is 0 and can be changed via deviceparameter.
ALso increased temperature accuracy of scd4x sensor via devparam.