### PR TITLE
Service mode dev

### DIFF
--- a/include/params/devp_service_timeout.h
+++ b/include/params/devp_service_timeout.h
@@ -1,7 +1,10 @@
 /**
- * SCD30/4x default value for automatic self calibration.
+ * Service mode timeout for deviceparameter.
+ * Every time when deviceparameter is used devp_comms uses timer to keep radio alive for some time. Default is 5 seconds.
+ * This timeout can be changed via this devparam.
  *
- * Copyright Thinnect Inc. 2021
+ * Copyright Thinnect Inc. 2022
+ * @author Lembitu Valdmets
  * @license MIT
  */
 #ifndef DEVP_SERVICE_MODE_H_

--- a/include/params/devp_service_timeout.h
+++ b/include/params/devp_service_timeout.h
@@ -10,14 +10,14 @@
 #include "devp.h"
 
 /**
- * Initialize scd default automatic self calibration parameter.
+ * Initialize default service mode timeout parameter.
  */
 void devp_service_mode_timeout_init ();
 
 /**
  * Get current timeout value in milliseconds.
  *
- * @return default value for ASC.
+ * @return service mode timeout in milliseconds.
  */
 uint32_t devp_service_mode_timeout_get ();
 

--- a/include/params/devp_service_timeout.h
+++ b/include/params/devp_service_timeout.h
@@ -1,0 +1,24 @@
+/**
+ * SCD30/4x default value for automatic self calibration.
+ *
+ * Copyright Thinnect Inc. 2021
+ * @license MIT
+ */
+#ifndef DEVP_SERVICE_MODE_H_
+#define DEVP_SERVICE_MODE_H_
+
+#include "devp.h"
+
+/**
+ * Initialize scd default automatic self calibration parameter.
+ */
+void devp_service_mode_timeout_init ();
+
+/**
+ * Get current timeout value in milliseconds.
+ *
+ * @return default value for ASC.
+ */
+uint32_t devp_service_mode_timeout_get ();
+
+#endif//DEVP_SERVICE_MODE_H_

--- a/src/params/devp_scd4x_service_mode.c
+++ b/src/params/devp_scd4x_service_mode.c
@@ -350,7 +350,7 @@ static int dp_scd4x_tempoffs_default_get (devp_t * param, void * value);
 static int dp_scd4x_tempoffs_default_set (devp_t * param, bool init, const void * value, uint8_t size);
 
 static devp_t m_dp_scd4x_tempoffs_default = {
-	.name = "scd4x_tempoffs_default",
+	.name = "scd4x_tffs_def",
 	.type = DP_TYPE_INT32,
 	.size = sizeof(int32_t),
 	.persist = true,

--- a/src/params/devp_service_timeout.c
+++ b/src/params/devp_service_timeout.c
@@ -3,7 +3,8 @@
  * Is stored in persistent memory.
  * Default value currently set to 5 sec
  *
- * Copyright Thinnect Inc. 2021
+ * Copyright Thinnect Inc. 2022
+ * @author Lembitu Valdmets
  * @license MIT
  */
 #include "devp_service_timeout.h"

--- a/src/params/devp_service_timeout.c
+++ b/src/params/devp_service_timeout.c
@@ -1,0 +1,50 @@
+/**
+ * Deviceparameter parameter to configure keep alive timeout for deviceparameter.
+ * Is stored in persistent memory.
+ * Default value currently set to 5 sec
+ *
+ * Copyright Thinnect Inc. 2021
+ * @license MIT
+ */
+#include "devp_service_timeout.h"
+
+#ifndef DEVP_SERVICE_TIMEOUT_MS
+#define DEVP_SERVICE_TIMEOUT_MS 5000
+#endif//DEVP_SERVICE_TIMEOUT_MS
+
+static uint32_t m_scd_default_asc;
+
+static int dp_service_mode_timeout_get (devp_t * param, void * value);
+static int dp_service_mode_timeout_set (devp_t * param, bool init, const void * value, uint8_t size);
+
+static devp_t m_dp_scd_default_asc = {
+	.name = "service_mode_timeout",
+	.type = DP_TYPE_UINT32,
+	.size = sizeof(uint32_t),
+	.persist = true,
+	.getf = dp_service_mode_timeout_get,
+	.setf = dp_service_mode_timeout_set
+};
+
+static int dp_service_mode_timeout_get (devp_t * param, void * value)
+{
+	*((uint32_t*)value) = m_scd_default_asc;
+	return sizeof(uint32_t);
+}
+
+static int dp_service_mode_timeout_set (devp_t * param, bool init, const void * value, uint8_t size)
+{
+	m_scd_default_asc = *((uint32_t*)value);
+	return sizeof(uint32_t);
+}
+
+void devp_service_mode_timeout_init ()
+{
+    m_scd_default_asc = DEVP_SERVICE_TIMEOUT_MS;
+    devp_register(&m_dp_scd_default_asc);
+}
+
+uint32_t devp_service_mode_timeout_get ()
+{
+    return m_scd_default_asc;
+}

--- a/src/params/devp_service_timeout.c
+++ b/src/params/devp_service_timeout.c
@@ -8,6 +8,7 @@
  */
 #include "devp_service_timeout.h"
 
+
 #ifndef DEVP_SERVICE_TIMEOUT_MS
 #define DEVP_SERVICE_TIMEOUT_MS 5000
 #endif//DEVP_SERVICE_TIMEOUT_MS
@@ -18,7 +19,7 @@ static int dp_service_mode_timeout_get (devp_t * param, void * value);
 static int dp_service_mode_timeout_set (devp_t * param, bool init, const void * value, uint8_t size);
 
 static devp_t m_dp_service_mode_timeout = {
-	.name = "service_mode_timeout",
+	.name = "service_to",
 	.type = DP_TYPE_UINT32,
 	.size = sizeof(uint32_t),
 	.persist = true,
@@ -35,7 +36,7 @@ static int dp_service_mode_timeout_get (devp_t * param, void * value)
 static int dp_service_mode_timeout_set (devp_t * param, bool init, const void * value, uint8_t size)
 {
 	m_service_mode_timeout = *((uint32_t*)value);
-	return sizeof(uint32_t);
+    return sizeof(uint32_t);
 }
 
 void devp_service_mode_timeout_init ()

--- a/src/params/devp_service_timeout.c
+++ b/src/params/devp_service_timeout.c
@@ -12,12 +12,12 @@
 #define DEVP_SERVICE_TIMEOUT_MS 5000
 #endif//DEVP_SERVICE_TIMEOUT_MS
 
-static uint32_t m_scd_default_asc;
+static uint32_t m_service_mode_timeout;
 
 static int dp_service_mode_timeout_get (devp_t * param, void * value);
 static int dp_service_mode_timeout_set (devp_t * param, bool init, const void * value, uint8_t size);
 
-static devp_t m_dp_scd_default_asc = {
+static devp_t m_dp_service_mode_timeout = {
 	.name = "service_mode_timeout",
 	.type = DP_TYPE_UINT32,
 	.size = sizeof(uint32_t),
@@ -28,23 +28,23 @@ static devp_t m_dp_scd_default_asc = {
 
 static int dp_service_mode_timeout_get (devp_t * param, void * value)
 {
-	*((uint32_t*)value) = m_scd_default_asc;
+	*((uint32_t*)value) = m_service_mode_timeout;
 	return sizeof(uint32_t);
 }
 
 static int dp_service_mode_timeout_set (devp_t * param, bool init, const void * value, uint8_t size)
 {
-	m_scd_default_asc = *((uint32_t*)value);
+	m_service_mode_timeout = *((uint32_t*)value);
 	return sizeof(uint32_t);
 }
 
 void devp_service_mode_timeout_init ()
 {
-    m_scd_default_asc = DEVP_SERVICE_TIMEOUT_MS;
-    devp_register(&m_dp_scd_default_asc);
+    m_service_mode_timeout = DEVP_SERVICE_TIMEOUT_MS;
+    devp_register(&m_dp_service_mode_timeout);
 }
 
 uint32_t devp_service_mode_timeout_get ()
 {
-    return m_scd_default_asc;
+    return m_service_mode_timeout;
 }


### PR DESCRIPTION
Added service mode timeout to temp-sense-node firmware. Now it is possible to change sleep block duration when using deviceparameter.
Default value is 5 sec, can be changed via service_to (uint32_t) and is persistent.
Tested successfully on ThinboxCO2 and Thinbox5